### PR TITLE
Fixed typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $> yarn add pikasprite
 ```js
 import 'pikasprite/build/spritesheet.css';
 
-const Pikachu = () => <i className={`pkspr pokemon-pikachu`}/>;
+const Pikachu = () => <i className={`pkspr-pokemon-pikachu`}/>;
 ```
 
 ## Icon List


### PR DESCRIPTION
Looking into the source code, this package needs the inserted '-' to work. This change will help reduce confusion.